### PR TITLE
Fix config weirdness

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -264,7 +264,7 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "nix-github-actions": "nix-github-actions",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_6",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -439,18 +439,6 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-6umX2oZ1GFsbWY+NKwp83Vhyzil89M40q1mCVVKwvqQ=",
-        "path": "/nix/store/x9nhs6ddgkfg17ciwbcpri465ah5wjg8-source",
-        "type": "path"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
         "lastModified": 1713805509,
         "narHash": "sha256-YgSEan4CcrjivCNO5ZNzhg7/8ViLkZ4CB/GrGBVSudo=",
         "owner": "NixOS",
@@ -486,7 +474,6 @@
         "home-manager": "home-manager",
         "ironhide": "ironhide",
         "matui": "matui",
-        "nixpkgs": "nixpkgs_6",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nixpkgs-wayland": "nixpkgs-wayland",
         "nur": "nur"

--- a/flake.nix
+++ b/flake.nix
@@ -18,93 +18,83 @@
     helix.url = "github:helix-editor/helix";
   };
 
-  outputs =
-    inputs@{ self
-    , nixpkgs
-    , nixpkgs-unstable
-    , home-manager
-    , nur
-    , ...
-    }:
-    let
-      username = "mumu";
-      system = "x86_64-linux";
-      # Configuration for `nixpkgs`
-      nixpkgsConfig = {
-        config = {
-          allowUnsupportedSystem = true;
-          allowBroken = false;
-          allowUnfree = true;
-          experimental-features = "nix-command flakes";
-          keep-derivations = true;
-          keep-outputs = true;
-          # try removing this every once in a while to see if deps stopped using it
-          permittedInsecurePackages = [ "nodejs-16.20.0" ];
-        };
+  outputs = inputs @ {
+    self,
+    nixpkgs-unstable,
+    home-manager,
+    nixpkgs-wayland,
+    nur,
+    ...
+  }: let
+    username = "mumu";
+    system = "x86_64-linux";
+    # Configuration for `nixpkgs`
+    nixpkgsConfig = {
+      config = {
+        allowUnsupportedSystem = true;
+        allowBroken = false;
+        allowUnfree = true;
+        experimental-features = "nix-command flakes";
+        keep-derivations = true;
+        keep-outputs = true;
+        # try removing this every once in a while to see if deps stopped using it
+        permittedInsecurePackages = ["nodejs-16.20.0"];
       };
-
-      overlays = {
-        # Overlays to add different versions `nixpkgs` into package set
-        unstable = _: prev: {
-          unstable = import nixpkgs-unstable
-            {
-              inherit (prev.stdenv) system;
-              inherit (nixpkgsConfig) config;
-            } // {
-            ironhide = inputs.ironhide.packages.${prev.stdenv.system}.ironhide;
-            matui = inputs.matui.packages.${prev.stdenv.system}.matui;
-            helix = inputs.helix.packages.${prev.stdenv.system}.helix;
-          };
-        };
-      };
-    in
-    {
-      nixosConfigurations = {
-        murph-icl-gen2 = nixpkgs.lib.nixosSystem {
-          inherit system;
-          pkgs = import nixpkgs {
-            system = "x86_64-linux";
-            inherit (nixpkgsConfig) config;
-            overlays = with overlays; [
-              nur.overlay
-              unstable
-            ];
-          };
-          specialArgs = {
-            inherit inputs username;
-          };
-          modules = [
-            ./modules/hardware/x1-extreme-gen2.nix
-            ./modules/hardware/drawingtablet.nix
-            ./modules/nixos
-            home-manager.nixosModules.home-manager
-            {
-              home-manager.useGlobalPkgs = true;
-              home-manager.useUserPackages = true;
-              home-manager.users.${username} = import ./modules/home-manager;
-              home-manager.extraSpecialArgs = {
-                inherit inputs username;
-              };
-            }
-            ({ pkgs, config, ... }: {
-              config = {
-                nix.settings = {
-                  # add binary caches
-                  trusted-public-keys = [
-                    "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-                    "nixpkgs-wayland.cachix.org-1:3lwxaILxMRkVhehr5StQprHdEo4IrE8sRho9R9HOLYA="
-                  ];
-                  substituters = [
-                    "https://cache.nixos.org"
-                    "https://nixpkgs-wayland.cachix.org"
-                  ];
-                };
-
-                nixpkgs.overlays = [ inputs.nixpkgs-wayland.overlay ];
-              };
+    };
+  in {
+    nixosConfigurations = {
+      murph-icl-gen2 = nixpkgs-unstable.lib.nixosSystem {
+        inherit system;
+        pkgs = import nixpkgs-unstable {
+          system = "x86_64-linux";
+          inherit (nixpkgsConfig) config;
+          overlays = [
+            nur.overlay
+            nixpkgs-wayland.overlay
+            (final: prev: {
+              inherit (inputs.ironhide.packages.${prev.stdenv.system}) ironhide;
+              inherit (inputs.matui.packages.${prev.stdenv.system}) matui;
+              inherit (inputs.helix.packages.${prev.stdenv.system}) helix;
             })
           ];
         };
+        specialArgs = {
+          inherit inputs username;
+        };
+        modules = [
+          ./modules/hardware/x1-extreme-gen2.nix
+          ./modules/hardware/drawingtablet.nix
+          ./modules/nixos
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.users.${username} = import ./modules/home-manager;
+            home-manager.extraSpecialArgs = {
+              inherit inputs username;
+            };
+          }
+          ({
+            pkgs,
+            config,
+            ...
+          }: {
+            config = {
+              nix.settings = {
+                # add binary caches
+                trusted-public-keys = [
+                  "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+                  "nixpkgs-wayland.cachix.org-1:3lwxaILxMRkVhehr5StQprHdEo4IrE8sRho9R9HOLYA="
+                ];
+                substituters = [
+                  "https://cache.nixos.org"
+                  "https://nixpkgs-wayland.cachix.org"
+                ];
+              };
+            };
+          })
+        ];
       };
     };
+  };
 }

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,5 +1,9 @@
-{ inputs, config, lib, pkgs, ... }: {
-
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
   programs.home-manager = {
     enable = true;
   };
@@ -20,14 +24,19 @@
       menu = "bemenu-run --no-overlap";
       modifier = "Mod4";
       startup = [
-        { command = "${pkgs.autotiling-rs}/bin/autotiling-rs"; always = true; }
+        {
+          command = "${pkgs.autotiling-rs}/bin/autotiling-rs";
+          always = true;
+        }
       ];
       # Status bar(s)
-      bars = [{
-        fonts.size = 13.0;
-        command = "waybar"; # You can change it if you want
-        position = "top";
-      }];
+      bars = [
+        {
+          fonts.size = 13.0;
+          command = "waybar"; # You can change it if you want
+          position = "top";
+        }
+      ];
       # Display device configuration
       output = {
         eDP-1 = {
@@ -62,18 +71,18 @@
       export WLR_NO_HARDWARE_CURSORS=1
       export WLR_RENDERER=vulkan,gles2,pixman
     '';
-    extraOptions = [ "--unsupported-gpu" ];
+    extraOptions = ["--unsupported-gpu"];
   };
 
   programs.waybar = {
     enable = true;
-    package = pkgs.unstable.waybar.override { upowerSupport = false; };
+    package = pkgs.waybar.override {upowerSupport = true;};
     settings = {
       mainBar = {
         layer = "bottom";
-        modules-left = [ "sway/workspaces" "sway/mode" ];
-        modules-center = [ "sway/window" ];
-        modules-right = [ "pulseaudio" "bluetooth" "network" "cpu" "memory" "temperature" "sway/language" "battery" "clock" "tray" ];
+        modules-left = ["sway/workspaces" "sway/mode"];
+        modules-center = ["sway/window"];
+        modules-right = ["pulseaudio" "bluetooth" "network" "cpu" "memory" "temperature" "sway/language" "battery" "clock" "tray"];
         "sway/mode".format = "<span style=\"italic\">{}</span>";
         tray.spacing = 10;
         clock = {
@@ -88,7 +97,7 @@
         temperature = {
           critical-threshold = 80;
           format = "{temperatureC}°C {icon}";
-          format-icons = [ "" "" "" ];
+          format-icons = ["" "" ""];
         };
         battery = {
           states = {
@@ -100,7 +109,7 @@
           format-charging = "{capacity}% ";
           format-plugged = "{capacity}% ";
           format-alt = "{time} {icon}";
-          format-icons = [ "" "" "" "" "" ];
+          format-icons = ["" "" "" "" ""];
         };
         network = {
           format-wifi = "{essid} ({signalStrength}%) ";
@@ -124,7 +133,7 @@
             phone = "";
             portable = "";
             car = "";
-            default = [ "" "" "" ];
+            default = ["" "" ""];
           };
           on-click = "pavucontrol";
         };
@@ -211,7 +220,7 @@
     enable = true;
     compression = true;
     controlMaster = "auto";
-    includes = [ "*.conf" ];
+    includes = ["*.conf"];
     # matchBlocks."*" =
     #   {
     #     identityFile = "~/.ssh/yubikey.pub";
@@ -229,8 +238,8 @@
     blueberry
     file
     htop
-    unstable.ironhide
-    unstable.matui # lightweight matrix tui client
+    ironhide
+    matui # lightweight matrix tui client
     nixpkgs-fmt
     ouch
     pavucontrol
@@ -268,32 +277,39 @@
     defaultTimeout = 5000;
   };
 
-  services.swayidle =
-    let
-      lockCommand = pkgs.swaylock + "/bin/swaylock -fF -c 000000";
-      swayMsgPath = config.wayland.windowManager.sway.package + /bin/swaymsg;
-    in
-    {
-      enable = true;
-      events = [
-        { event = "before-sleep"; command = lockCommand; }
-        { event = "after-resume"; command = ''${swayMsgPath} "output * dpms on"''; }
-        { event = "lock"; command = lockCommand; }
-      ];
-      timeouts = [
-        {
-          timeout = 60 * 6;
-          command = "${swayMsgPath} \"output * dpms off\"";
-          resumeCommand = "${swayMsgPath} \"output * dpms on\"";
-        }
-        {
-          timeout = 60 * 10;
-          command = lockCommand;
-        }
-        {
-          timeout = 60 * 15;
-          command = "systemctl suspend";
-        }
-      ];
-    };
+  services.swayidle = let
+    lockCommand = pkgs.swaylock + "/bin/swaylock -fF -c 000000";
+    swayMsgPath = config.wayland.windowManager.sway.package + /bin/swaymsg;
+  in {
+    enable = true;
+    events = [
+      {
+        event = "before-sleep";
+        command = lockCommand;
+      }
+      {
+        event = "after-resume";
+        command = ''${swayMsgPath} "output * dpms on"'';
+      }
+      {
+        event = "lock";
+        command = lockCommand;
+      }
+    ];
+    timeouts = [
+      {
+        timeout = 60 * 6;
+        command = "${swayMsgPath} \"output * dpms off\"";
+        resumeCommand = "${swayMsgPath} \"output * dpms on\"";
+      }
+      {
+        timeout = 60 * 10;
+        command = lockCommand;
+      }
+      {
+        timeout = 60 * 15;
+        command = "systemctl suspend";
+      }
+    ];
+  };
 }

--- a/modules/home-manager/helix.nix
+++ b/modules/home-manager/helix.nix
@@ -1,8 +1,12 @@
-{ config, pkgs, lib, ... }:
 {
+  config,
+  pkgs,
+  lib,
+  ...
+}: {
   programs.helix = {
     enable = true;
-    package = pkgs.unstable.helix;
+    package = pkgs.helix;
     defaultEditor = true;
     settings = {
       theme = "jellybeans";
@@ -21,7 +25,7 @@
           name = "javascript";
           formatter = {
             command = "prettier";
-            args = [ "--parser" "typescript" ];
+            args = ["--parser" "typescript"];
           };
           auto-format = true;
         }
@@ -29,7 +33,7 @@
           name = "typescript";
           formatter = {
             command = "prettier";
-            args = [ "--parser" "typescript" ];
+            args = ["--parser" "typescript"];
           };
           auto-format = true;
         }
@@ -37,7 +41,7 @@
           name = "python";
           formatter = {
             command = "black";
-            args = [ "--quiet" "-" ];
+            args = ["--quiet" "-"];
           };
           auto-format = true;
         }
@@ -74,11 +78,11 @@
         #     },
         #     format = {  enable = false  }
         #   }
-        # } 
+        # }
         {
           name = "yaml";
-          file-types = [ "yaml" "yml" ];
-          language-servers = [ "yaml-language-server" ];
+          file-types = ["yaml" "yml"];
+          language-servers = ["yaml-language-server"];
         }
       ];
       language-server = {
@@ -135,9 +139,9 @@
     nodePackages.prettier # typescript, js
     vscode-langservers-extracted # css, json, html
     yaml-language-server # yaml
-    # - vscode-github-actions equivalent? 
+    # - vscode-github-actions equivalent?
     #   - see https://github.com/helix-editor/helix/issues/6988
-    #   - see https://github.com/actions/languageservices/issues/56    
+    #   - see https://github.com/actions/languageservices/issues/56
     # end helix language support
   ];
 }


### PR DESCRIPTION
- Fixed flake.nix references to non-existent `nixpkgs` input so they all refer to `nixpkgs-unstable` instead
- Fixed overlays to make sense and remove weird nesting -- no more `unstable` namespace under `pkgs` since `pkgs` is unstable already
- Simplified some things

Diffs look awful because my nix code formatter made different choices than previous. Sorry. :-(